### PR TITLE
Avoided hang the terminal when the execution of server is aborted

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,3 +1,5 @@
+import sys
+import os
 import json
 from threading import Thread
 
@@ -156,4 +158,12 @@ def data_loop(wsock, message):
 lora = Lora(simulate=True, mongo_host=config.mongo_host, mongo_port=config.mongo_port)
 server = WSGIServer(("0.0.0.0", config.server_port), app, handler_class=WebSocketHandler)
 print "Serving on port {}".format(config.server_port)
-server.serve_forever()
+
+try:
+    server.serve_forever()
+except KeyboardInterrupt:
+        print 'Script interrupted'
+        try:
+            sys.exit(0)
+        except SystemExit:
+            os._exit(0)


### PR DESCRIPTION
When this keyboard command was used (`CTRL + C`) it left the script hanged in the terminal.

I believe this PR fix that. Please, review this code and tell me what do you think.