### PR TITLE
Added link to view position of balloon on Google Maps

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -15,6 +15,11 @@ ws.onmessage = function (evt) {
 
 	if(json.action == "payload_data") {
 		data = json.data;
+
+		// Set link to view position of ballon on a Google Maps
+		let linkGoogleMaps = document.getElementById('link-google-maps');
+		linkGoogleMaps.href = `https://www.google.com/maps/search/?api=1&query=${data.lat},${data.lon}`;
+
 		var str = data.channel + " " + data.payload + ": " +
 				"lat=" + data.lat + " lon=" + data.lon + " alt=" + data.alt +
 				", t=" + data.time;

--- a/views/index.html
+++ b/views/index.html
@@ -69,6 +69,7 @@
     <div id="footer" style="position:fixed;z-index:1;width:100%;bottom:0px;left:0px;background: #444;color:#fff;">
         <div style="float: left;padding:8px;">FlyPi</div>
         <div id="container" style="float: left;padding:8px;"></div>
+        <div style="float: left;padding:8px;"><a href="#" target="_blank" id="link-google-maps">View on Google Maps</a></div>
 
         <div style="position:absolute;right:0;margin-top:6px;display: table;">
             <span id="current_session" style="padding:8px;"></span>


### PR DESCRIPTION
This pull request add a link on the footer of application to view position of the balloon on Google Maps. 

For future improvements, here is a link to documentation (API token is not necessary): https://developers.google.com/maps/documentation/urls/guide 