### PR TITLE
Fix loading module on windows systems

### DIFF
--- a/pits/modules/lora_gateway.py
+++ b/pits/modules/lora_gateway.py
@@ -6,7 +6,7 @@ import random
 from threading import Thread
 import time
 
-from utils import gateway_time_to_timestamp
+from pits.modules.utils import gateway_time_to_timestamp
 
 class Lora:
 


### PR DESCRIPTION
Module `utils` don't load in windows systems. This PR fix the issue.